### PR TITLE
fix(AesGcm): pass correct request counter to initializeIV #5

### DIFF
--- a/lib-vau-csharp/crypto/AesGcm.cs
+++ b/lib-vau-csharp/crypto/AesGcm.cs
@@ -53,7 +53,7 @@ namespace lib_vau_csharp.crypto
         private void initializeAes(byte[] random, byte[] assocData, byte[] key)
         {
             KeyParameter keyParam = ParameterUtilities.CreateKeyParameter("AES", key);
-            ivValue = initializeIV(random.Take(random.Length - 8).ToArray(), 1);
+            ivValue = initializeIV(random.Take(random.Length - 8).ToArray(), BitConverter.ToInt64(random.Skip(random.Length - 8).Reverse().ToArray(), 0));
             var aes_parameters = new AeadParameters(keyParam, 128, ivValue, assocData);
             m_encCipher.Init(true, aes_parameters);
             m_decCipher.Init(false, aes_parameters);


### PR DESCRIPTION
Instead of fixed value: 1, use the passed request counter part of the random string

With release v1.0.2 #5 is not fixed.
See: https://github.com/gematik/lib-vau-csharp/issues/5#issuecomment-2413647979

fixes #5 

two different vau requests with increased counters are encrypted and decrypted successfully

```SH
vau-proxy-server           | 11:53:55.454 VPS INFO VauServerController: Received request for VAU-CID: /1728993234887
vau-proxy-server           | 11:53:55.454 VPS TRACE EncryptedVauMessage: trying to decrypt:
vau-proxy-server           |       Complete message     : 0200010000000000000001a537789d686e23fdc39af43e259e40cbec97208e017b58a715dff1deecd9c5c93a132c1900000000000000013877a5c808e780c0573a01f00a495da2dde5da252b0f4730b5323cdd899f60a2a19f5a0a3e08461af3d7e14d46067f259ec9c0da9378445b712d6ea481214e08b6accadc7699273275720cf95d7bcd5477f59ee3e79347c8ca9258e9d54a98f5501e26ada845cf84f9a4a02ebeda3a316d3938e19ce1102fc91152c0b607e169a22dbe99a8
vau-proxy-server           |       Message size (Bytes) : 188
vau-proxy-server           |       Complete header      : 0200010000000000000001a537789d686e23fdc39af43e259e40cbec97208e017b58a715dff1deecd9c5c9
vau-proxy-server           |       Key to decrypt (K2_c2s_app_data): 11cde042471bc1e1c4c39c6c4db5458e8abdbd6d584adb57fe028b8bff7fe618
vau-proxy-server           |       -------------------------------
vau-proxy-server           |       Version  (1 Byte): 02
vau-proxy-server           |       PU       (1 Byte): 00
vau-proxy-server           |       Request  (1 Byte): 01
vau-proxy-server           |       Counter  (8 Byte): 0000000000000001
vau-proxy-server           |       KeyId   (32 Byte): a537789d686e23fdc39af43e259e40cbec97208e017b58a715dff1deecd9c5c9
vau-proxy-server           |       IV      (12 Byte): 3a132c190000000000000001
vau-proxy-server           |       CT + GMAC        : 3877a5c808e780c0573a01f00a495da2dde5da252b0f4730b5323cdd899f60a2a19f5a0a3e08461af3d7e14d46067f259ec9c0da9378445b712d6ea481214e08b6accadc7699273275720cf95d7bcd5477f59ee3e79347c8ca9258e9d54a98f5501e26ada845cf84f9a4a02ebeda3a316d3938e19ce1102fc91152c0b607e169a22dbe99a8
vau-proxy-server           | 
vau-proxy-server           | 11:53:55.455 VPS TRACE AbstractVauStateMachine: Successful decrypted ct as: 
vau-proxy-server           |  GET /epa/authz/v1/getNonce HTTP/1.1
vau-proxy-server           | Host: 127.0.0.1
vau-proxy-server           | Content-Length: 0
vau-proxy-server           | x-useragent: ClientID/3.79.0
vau-proxy-server           | 
```

```SH
vau-proxy-server           | 11:53:56.409 VPS INFO VauServerController: Received request for VAU-CID: /1728993234887
vau-proxy-server           | 11:53:56.410 VPS TRACE EncryptedVauMessage: trying to decrypt:
vau-proxy-server           |       Complete message     : 0200010000000000000002a537789d686e23fdc39af43e259e40cbec97208e017b58a715dff1deecd9c5c9428f68000000000000000002fad3b016e9d13602400861aacf7b4cd766443a3f75362dd9765edf7e784afe16ecb4696cde94104f1500fae9793d531fc6727af88c19aca9c886b452b6771325a4508aece836f407f976c1767609a77fc368df0c3199546cf0762e1604b4b6519b42298abf35ee93c851dfd9c89f0bf319f7fa922cad153511c0742909ba0bd39d864718418ce756e21438d2f0aece35f7d60b8aebf6e85e7426
vau-proxy-server           |       Message size (Bytes) : 209
vau-proxy-server           |       Complete header      : 0200010000000000000002a537789d686e23fdc39af43e259e40cbec97208e017b58a715dff1deecd9c5c9
vau-proxy-server           |       Key to decrypt (K2_c2s_app_data): 11cde042471bc1e1c4c39c6c4db5458e8abdbd6d584adb57fe028b8bff7fe618
vau-proxy-server           |       -------------------------------
vau-proxy-server           |       Version  (1 Byte): 02
vau-proxy-server           |       PU       (1 Byte): 00
vau-proxy-server           |       Request  (1 Byte): 01
vau-proxy-server           |       Counter  (8 Byte): 0000000000000002
vau-proxy-server           |       KeyId   (32 Byte): a537789d686e23fdc39af43e259e40cbec97208e017b58a715dff1deecd9c5c9
vau-proxy-server           |       IV      (12 Byte): 428f68000000000000000002
vau-proxy-server           |       CT + GMAC        : fad3b016e9d13602400861aacf7b4cd766443a3f75362dd9765edf7e784afe16ecb4696cde94104f1500fae9793d531fc6727af88c19aca9c886b452b6771325a4508aece836f407f976c1767609a77fc368df0c3199546cf0762e1604b4b6519b42298abf35ee93c851dfd9c89f0bf319f7fa922cad153511c0742909ba0bd39d864718418ce756e21438d2f0aece35f7d60b8aebf6e85e7426
vau-proxy-server           | 
vau-proxy-server           | 11:53:56.410 VPS TRACE AbstractVauStateMachine: Successful decrypted ct as: 
vau-proxy-server           |  GET /epa/authz/v1/send_authorization_request_sc HTTP/1.1
vau-proxy-server           | Host: 127.0.0.1
vau-proxy-server           | Content-Length: 0
vau-proxy-server           | x-useragent: ClientID/3.79.0
vau-proxy-server           | 
```