### PR TITLE
fix(handshake): build cbor structur - no json serialize

### DIFF
--- a/lib-vau-csharp/VauClientStateMachine.cs
+++ b/lib-vau-csharp/VauClientStateMachine.cs
@@ -42,7 +42,7 @@ namespace lib_vau_csharp
 
         public byte[] generateMessage1()
         {
-            this.clientTranscript = this.vauMessage1.toCBOR();  // A_24428: encode in CBOR
+            this.clientTranscript = this.vauMessage1.toCbor();  // A_24428: encode in CBOR
             return this.clientTranscript;
         }
 
@@ -81,7 +81,7 @@ namespace lib_vau_csharp
             byte[] transcriptClientHash = DigestUtils.Sha256(clientTranscriptToSend);
             byte[] aeadCipherTextMessage3KeyKonfirmation = kem.EncryptAead(kdfClientKey2.ClientToServerKeyKonfirmation, transcriptClientHash);
             VauMessage3 vauMessage3 = new VauMessage3(aeadCiphertextMessage3, aeadCipherTextMessage3KeyKonfirmation);
-            byte[] vauMessage3Encoded = CborUtils.EncodeToCbor(vauMessage3);
+            byte[] vauMessage3Encoded = vauMessage3.toCbor();
             return vauMessage3Encoded;
         }
 
@@ -90,7 +90,7 @@ namespace lib_vau_csharp
             this.clientKemResult2 = KEM.EncapsulateMessage(transferredSignedServerPublicKeyList.EcdhPublicKey.ToEcPublicKey(), transferredSignedServerPublicKeyList.ToKyberPublicKey());
             VauMessage3InnerLayer vauMessage3InnerLayer = new VauMessage3InnerLayer(clientKemResult2.EcdhCt, clientKemResult2.KyberCt, false, false);
 
-            byte[] message3InnerLayerEncoded = CborUtils.EncodeToCbor(vauMessage3InnerLayer);
+            byte[] message3InnerLayerEncoded = vauMessage3InnerLayer.toCbor();
             byte[] aeadCiphertextMessage3 = kem.EncryptAead(kdfClientKey1.ClientToServer, message3InnerLayerEncoded);
             return aeadCiphertextMessage3;
         }

--- a/lib-vau-csharp/data/VauMessage1.cs
+++ b/lib-vau-csharp/data/VauMessage1.cs
@@ -41,9 +41,14 @@ namespace lib_vau_csharp.data
             return JsonConvert.SerializeObject(this);
         }
 
-        public byte[] toCBOR()
+        public byte[] toCbor()
         {
-            return CborUtils.EncodeToCbor(this);
+            CBORObject cborVauKey = CBORObject.NewOrderedMap();     // Reihenfolge Tags wird beibehalten (prinzipiell ist die Reihenfolge egal)
+            cborVauKey.Add("MessageType", _messageType);
+            cborVauKey.Add("ECDH_PK", CBORObject.NewMap().Add("x", EcdhPublicKey.X).Add("y", EcdhPublicKey.Y).Add("crv", "P-256"));
+            cborVauKey.Add("Kyber768_PK",  KyberPublicKeyBytes);
+
+            return cborVauKey.EncodeToBytes();
         }
 
         public static VauMessage1 fromCbor(byte[] encodedObject)

--- a/lib-vau-csharp/data/VauMessage1.cs
+++ b/lib-vau-csharp/data/VauMessage1.cs
@@ -43,7 +43,7 @@ namespace lib_vau_csharp.data
 
         public byte[] toCbor()
         {
-            CBORObject cborVauKey = CBORObject.NewOrderedMap();     // Reihenfolge Tags wird beibehalten (prinzipiell ist die Reihenfolge egal)
+            CBORObject cborVauKey = CBORObject.NewOrderedMap();
             cborVauKey.Add("MessageType", _messageType);
             cborVauKey.Add("ECDH_PK", CBORObject.NewMap().Add("x", EcdhPublicKey.X).Add("y", EcdhPublicKey.Y).Add("crv", "P-256"));
             cborVauKey.Add("Kyber768_PK",  KyberPublicKeyBytes);

--- a/lib-vau-csharp/data/VauMessage3.cs
+++ b/lib-vau-csharp/data/VauMessage3.cs
@@ -38,6 +38,15 @@ namespace lib_vau_csharp.data
             AeadCtKeyKonfirmation = aeadCtKeyKonfirmation;
         }
 
+        public byte[] toCbor() {
+          CBORObject cborVauKey = CBORObject.NewOrderedMap();     // Reihenfolge Tags wird beibehalten (prinzipiell ist die Reihenfolge egal)
+          cborVauKey.Add("MessageType", _messageType);
+          cborVauKey.Add("AEAD_ct", AeadCt);
+          cborVauKey.Add("AEAD_ct_key_confirmation", AeadCtKeyKonfirmation);
+
+          return cborVauKey.EncodeToBytes();
+        }
+
         public static VauMessage3 fromCbor(byte[] encodedObject)
         {
             try

--- a/lib-vau-csharp/data/VauMessage3.cs
+++ b/lib-vau-csharp/data/VauMessage3.cs
@@ -39,7 +39,7 @@ namespace lib_vau_csharp.data
         }
 
         public byte[] toCbor() {
-          CBORObject cborVauKey = CBORObject.NewOrderedMap();     // Reihenfolge Tags wird beibehalten (prinzipiell ist die Reihenfolge egal)
+          CBORObject cborVauKey = CBORObject.NewOrderedMap();
           cborVauKey.Add("MessageType", _messageType);
           cborVauKey.Add("AEAD_ct", AeadCt);
           cborVauKey.Add("AEAD_ct_key_confirmation", AeadCtKeyKonfirmation);

--- a/lib-vau-csharp/data/VauMessage3InnerLayer.cs
+++ b/lib-vau-csharp/data/VauMessage3InnerLayer.cs
@@ -41,6 +41,16 @@ namespace lib_vau_csharp.data
             Eso = eso;
         }
 
+        public byte[] toCbor() {
+          CBORObject cborVauKey = CBORObject.NewOrderedMap();     // Reihenfolge Tags wird beibehalten (prinzipiell ist die Reihenfolge egal)
+          cborVauKey.Add("ECDH_ct", EcdhCt);
+          cborVauKey.Add("Kyber768_ct", KyberCt);
+          cborVauKey.Add("ERP",  Erp);
+          cborVauKey.Add("ESO",  Eso);
+
+          return cborVauKey.EncodeToBytes();
+        }
+
         public static VauMessage3InnerLayer fromCbor(byte[] encodedObject)
         {
             try

--- a/lib-vau-csharp/data/VauMessage3InnerLayer.cs
+++ b/lib-vau-csharp/data/VauMessage3InnerLayer.cs
@@ -42,7 +42,7 @@ namespace lib_vau_csharp.data
         }
 
         public byte[] toCbor() {
-          CBORObject cborVauKey = CBORObject.NewOrderedMap();     // Reihenfolge Tags wird beibehalten (prinzipiell ist die Reihenfolge egal)
+          CBORObject cborVauKey = CBORObject.NewOrderedMap();
           cborVauKey.Add("ECDH_ct", EcdhCt);
           cborVauKey.Add("Kyber768_ct", KyberCt);
           cborVauKey.Add("ERP",  Erp);


### PR DESCRIPTION
fix #6 

Considering https://gemspec.gematik.de/docs/gemSpec/gemSpec_Krypt/latest/#A_24425-01 and following the data structure encoded to cbor, it never states that the data structure should be a valid json object.

Since native json (without binary extensions) objects are serializing binary data to base64, those hand shake requests with binary data are failing against RU environments.

dc-mocks/tiger proxies vau service is allowing cbor fields with binary or base64 encoded data.

To avoid wrong implementations the lib-vau should implement the correct way to do it.