### PR TITLE
Fix test failures under Linux

### DIFF
--- a/lib-vau-csharp-test/Constants.cs
+++ b/lib-vau-csharp-test/Constants.cs
@@ -1,0 +1,34 @@
+using System.IO;
+
+using lib_vau_csharp_test.util;
+
+using lib_vau_csharp.data;
+
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+
+namespace lib_vau_csharp_test
+{
+    public static class Constants
+    {
+        public static class Keys
+        {
+            public static readonly EccKyberKeyPair EccKyberKeyPair = FileUtil.ReadEccKyberKeyPairFromFile(Paths.VauServerKeys);
+            public static readonly ECPrivateKeyParameters ECPrivateKeyParameters = (ECPrivateKeyParameters)PrivateKeyFactory.CreateKey(FileUtil.ReadAllBytes(Paths.VauSigKey));
+        }
+
+        public static class Certificates
+        {
+            public static readonly byte[] ServerAutCertificate = FileUtil.ReadAllBytes(Paths.VauSigCert);
+            public static readonly byte[] OcspResponseAutCertificate = FileUtil.ReadAllBytes(Paths.OcspResponseVauSig);
+        }
+
+        public static class Paths
+        {
+            public static readonly string VauServerKeys = Path.Combine("resources", "vau_server_keys.cbor");
+            public static readonly string VauSigKey = Path.Combine("resources", "vau-sig-key.der");
+            public static readonly string VauSigCert = Path.Combine("resources", "vau_sig_cert.der");
+            public static readonly string OcspResponseVauSig = Path.Combine("resources", "ocsp-response-vau-sig.der");
+        }
+    }
+}

--- a/lib-vau-csharp-test/HandShakeTests.cs
+++ b/lib-vau-csharp-test/HandShakeTests.cs
@@ -16,11 +16,10 @@
 
 using lib_vau_csharp;
 using lib_vau_csharp.data;
-using lib_vau_csharp_test.util;
+
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Security;
+
 using System;
 using System.Text;
 using System.Threading.Tasks;
@@ -36,17 +35,10 @@ namespace lib_vau_csharp_test
         [SetUp]
         public void Setup()
         {
-            EccKyberKeyPair eccKyberKeyPair = FileUtil.ReadEccKyberKeyPairFromFile(@"resources\\vau_server_keys.cbor");
-            byte[] privateKeyBytes = FileUtil.ReadAllBytes(@"resources\\vau-sig-key.der");
-            ECPrivateKeyParameters eCPrivateKeyParameters = (ECPrivateKeyParameters)PrivateKeyFactory.CreateKey(privateKeyBytes);
+            VauPublicKeys vauBasicPublicKey = new VauPublicKeys(Constants.Keys.EccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
+            SignedPublicVauKeys signedPublicVauKeys = SignedPublicVauKeys.Sign(Constants.Certificates.ServerAutCertificate, Constants.Keys.ECPrivateKeyParameters, Constants.Certificates.OcspResponseAutCertificate, 1, vauBasicPublicKey);
 
-            byte[] serverAutCertificate = FileUtil.ReadAllBytes(@"resources\\vau_sig_cert.der");
-            byte[] ocspResponseAutCertificate = FileUtil.ReadAllBytes(@"resources\\ocsp-response-vau-sig.der");
-
-            VauPublicKeys vauBasicPublicKey = new VauPublicKeys(eccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
-            SignedPublicVauKeys signedPublicVauKeys = SignedPublicVauKeys.Sign(serverAutCertificate, eCPrivateKeyParameters, ocspResponseAutCertificate, 1, vauBasicPublicKey);
-
-            vauServer = new VauServer(url, signedPublicVauKeys, eccKyberKeyPair);
+            vauServer = new VauServer(url, signedPublicVauKeys, Constants.Keys.EccKyberKeyPair);
             vauServer.StartAsync();
 
         }

--- a/lib-vau-csharp-test/KemTest.cs
+++ b/lib-vau-csharp-test/KemTest.cs
@@ -17,13 +17,13 @@
 using lib_vau_csharp;
 using lib_vau_csharp.crypto;
 using lib_vau_csharp.data;
-using lib_vau_csharp_test.util;
+
 using NUnit.Framework;
 using NUnit.Framework.Legacy;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Pqc.Crypto.Crystals.Kyber;
-using Org.BouncyCastle.Security;
+
 using System;
 using System.Text;
 
@@ -55,18 +55,10 @@ namespace lib_vau_csharp_test
 
         public void doHandShakeTest(bool isPu)
         {
+            VauPublicKeys vauBasicPublicKey = new VauPublicKeys(Constants.Keys.EccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
+            SignedPublicVauKeys signedPublicVauKeys = SignedPublicVauKeys.Sign(Constants.Certificates.ServerAutCertificate, Constants.Keys.ECPrivateKeyParameters, Constants.Certificates.OcspResponseAutCertificate, 1, vauBasicPublicKey);
 
-            EccKyberKeyPair eccKyberKeyPair = FileUtil.ReadEccKyberKeyPairFromFile(@"resources\\vau_server_keys.cbor");
-            byte[] privateKeyBytes = FileUtil.ReadAllBytes(@"resources\\vau-sig-key.der");
-            ECPrivateKeyParameters eCPrivateKeyParameters = (ECPrivateKeyParameters)PrivateKeyFactory.CreateKey(privateKeyBytes);
-
-            byte[] serverAutCertificate = FileUtil.ReadAllBytes(@"resources\\vau_sig_cert.der");
-            byte[] ocspResponseAutCertificate = FileUtil.ReadAllBytes(@"resources\\ocsp-response-vau-sig.der");
-
-            VauPublicKeys vauBasicPublicKey = new VauPublicKeys(eccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
-            SignedPublicVauKeys signedPublicVauKeys = SignedPublicVauKeys.Sign(serverAutCertificate, eCPrivateKeyParameters, ocspResponseAutCertificate, 1, vauBasicPublicKey);
-
-            VauServerStateMachine vauServerStateMachine = new VauServerStateMachine(signedPublicVauKeys, eccKyberKeyPair);
+            VauServerStateMachine vauServerStateMachine = new VauServerStateMachine(signedPublicVauKeys, Constants.Keys.EccKyberKeyPair);
             vauServerStateMachine.isPu = isPu;
             VauClientStateMachine vauClientStateMachine = new VauClientStateMachine();
             vauClientStateMachine.isPu = isPu;

--- a/lib-vau-csharp-test/ReadKeysTests.cs
+++ b/lib-vau-csharp-test/ReadKeysTests.cs
@@ -19,7 +19,7 @@ using lib_vau_csharp_test.util;
 using NUnit.Framework;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Pqc.Crypto.Crystals.Kyber;
-using Org.BouncyCastle.Security;
+
 using System;
 
 namespace lib_vau_csharp_test
@@ -30,7 +30,7 @@ namespace lib_vau_csharp_test
         [Test]
         public void TestReadPrivateSpec()
         {
-            EccKyberKeyPair eccKyberKeyPair = FileUtil.ReadEccKyberKeyPairFromFile(@"resources\\vau_server_keys.cbor");
+            EccKyberKeyPair eccKyberKeyPair = FileUtil.ReadEccKyberKeyPairFromFile(Constants.Paths.VauServerKeys);
             Assert.That("EC", Is.EqualTo(((ECPublicKeyParameters)eccKyberKeyPair.EcdhKeyPair.Public).AlgorithmName));
             Assert.That("EC", Is.EqualTo(((ECPrivateKeyParameters)eccKyberKeyPair.EcdhKeyPair.Private).AlgorithmName));
 
@@ -41,15 +41,8 @@ namespace lib_vau_csharp_test
         [Test]
         public void TestSignPublicVauKeys()
         {
-            EccKyberKeyPair eccKyberKeyPair = FileUtil.ReadEccKyberKeyPairFromFile(@"resources\\vau_server_keys.cbor");
-            byte[] privateKeyBytes = FileUtil.ReadAllBytes(@"resources\\vau-sig-key.der");
-            ECPrivateKeyParameters eCPrivateKeyParameters = (ECPrivateKeyParameters)PrivateKeyFactory.CreateKey(privateKeyBytes);
-
-            byte[] serverAutCertificate = FileUtil.ReadAllBytes(@"resources\\vau_sig_cert.der");
-            byte[] ocspResponseAutCertificate = FileUtil.ReadAllBytes(@"resources\\ocsp-response-vau-sig.der");
-
-            VauPublicKeys vauBasicPublicKey = new VauPublicKeys(eccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
-            SignedPublicVauKeys signedPublicVauKeys = SignedPublicVauKeys.Sign(serverAutCertificate, eCPrivateKeyParameters, ocspResponseAutCertificate, 1, vauBasicPublicKey);
+            VauPublicKeys vauBasicPublicKey = new VauPublicKeys(Constants.Keys.EccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
+            SignedPublicVauKeys signedPublicVauKeys = SignedPublicVauKeys.Sign(Constants.Certificates.ServerAutCertificate, Constants.Keys.ECPrivateKeyParameters, Constants.Certificates.ServerAutCertificate, 1, vauBasicPublicKey);
 
             Assert.That(vauBasicPublicKey.Iat, Is.EqualTo(signedPublicVauKeys.ExtractVauKeys().Iat));
             Assert.That(vauBasicPublicKey.Exp, Is.EqualTo(signedPublicVauKeys.ExtractVauKeys().Exp));

--- a/lib-vau-csharp-test/VauStateMachineTest.cs
+++ b/lib-vau-csharp-test/VauStateMachineTest.cs
@@ -15,35 +15,23 @@
  */
 
 using lib_vau_csharp;
-using lib_vau_csharp.crypto;
 using lib_vau_csharp.data;
-using lib_vau_csharp_test.util;
+
 using NUnit.Framework;
-using Org.BouncyCastle.Crypto.Parameters;
-using Org.BouncyCastle.Security;
+
 using System;
 
 namespace lib_vau_csharp_test
 {
     public class VauStateMachineTest
     {
-        private EccKyberKeyPair eccKyberKeyPair;
         private SignedPublicVauKeys signedPublicVauKeys;
-
 
         [SetUp]
         public void Setup()
         {
-            // Prepare Keys
-            eccKyberKeyPair = FileUtil.ReadEccKyberKeyPairFromFile(@"resources\\vau_server_keys.cbor");
-            byte[] privateKeyBytes = FileUtil.ReadAllBytes(@"resources\\vau-sig-key.der");
-            ECPrivateKeyParameters eCPrivateKeyParameters = (ECPrivateKeyParameters)PrivateKeyFactory.CreateKey(privateKeyBytes);
-
-            byte[] serverAutCertificate = FileUtil.ReadAllBytes(@"resources\\vau_sig_cert.der");
-            byte[] ocspResponseAutCertificate = FileUtil.ReadAllBytes(@"resources\\ocsp-response-vau-sig.der");
-
-            VauPublicKeys vauBasicPublicKey = new VauPublicKeys(eccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
-            signedPublicVauKeys = SignedPublicVauKeys.Sign(serverAutCertificate, eCPrivateKeyParameters, ocspResponseAutCertificate, 1, vauBasicPublicKey);
+            VauPublicKeys vauBasicPublicKey = new VauPublicKeys(Constants.Keys.EccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
+            signedPublicVauKeys = SignedPublicVauKeys.Sign(Constants.Certificates.ServerAutCertificate, Constants.Keys.ECPrivateKeyParameters, Constants.Certificates.OcspResponseAutCertificate, 1, vauBasicPublicKey);
         }
 
         [Test]
@@ -54,7 +42,7 @@ namespace lib_vau_csharp_test
 
             Assert.DoesNotThrow(() => {
                 client = new VauClientStateMachine();
-                server = new VauServerStateMachine(signedPublicVauKeys, eccKyberKeyPair);
+                server = new VauServerStateMachine(signedPublicVauKeys, Constants.Keys.EccKyberKeyPair);
 
                 byte[] pMessage1 = client.generateMessage1();
                 byte[] pMessage2 = server.receiveMessage1(pMessage1);


### PR DESCRIPTION
Tests fail under Linux due to the usage of hardcoded Windows path separators. Use Path.Combine and move keys/certificates to constants to reduce code duplication.