### PR TITLE
Make request counter incrementation thread safe

### DIFF
--- a/lib-vau-csharp-test/VauStateMachineTest.cs
+++ b/lib-vau-csharp-test/VauStateMachineTest.cs
@@ -22,37 +22,38 @@ using lib_vau_csharp.data;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace lib_vau_csharp_test
 {
     public class VauStateMachineTest
     {
         private SignedPublicVauKeys signedPublicVauKeys;
+        
+        private VauClientStateMachine client;
+        private VauServerStateMachine server;
 
         [SetUp]
         public void Setup()
         {
             VauPublicKeys vauBasicPublicKey = new VauPublicKeys(Constants.Keys.EccKyberKeyPair, "VAU Server Keys", TimeSpan.FromDays(30));
             signedPublicVauKeys = SignedPublicVauKeys.Sign(Constants.Certificates.ServerAutCertificate, Constants.Keys.ECPrivateKeyParameters, Constants.Certificates.OcspResponseAutCertificate, 1, vauBasicPublicKey);
+            
+            client = new VauClientStateMachine();
+            server = new VauServerStateMachine(signedPublicVauKeys, Constants.Keys.EccKyberKeyPair);
+
+            byte[] pMessage1 = client.generateMessage1();
+            byte[] pMessage2 = server.receiveMessage1(pMessage1);
+            byte[] pMessage3 = client.receiveMessage2(pMessage2);
+            byte[] pMessage4 = server.receiveMessage3(pMessage3);
+            client.receiveMessage4(pMessage4);
         }
 
         [Test]
         public void SimpleTest()
         {
-            VauClientStateMachine client;
-            VauServerStateMachine server;
-
             Assert.DoesNotThrow(() =>
             {
-                client = new VauClientStateMachine();
-                server = new VauServerStateMachine(signedPublicVauKeys, Constants.Keys.EccKyberKeyPair);
-
-                byte[] pMessage1 = client.generateMessage1();
-                byte[] pMessage2 = server.receiveMessage1(pMessage1);
-                byte[] pMessage3 = client.receiveMessage2(pMessage2);
-                byte[] pMessage4 = server.receiveMessage3(pMessage3);
-                client.receiveMessage4(pMessage4);
-
                 int messageCount = 3;
                 long before = client.RequestCounter;
                 for (int i = 0; i < messageCount; i++)
@@ -76,6 +77,23 @@ namespace lib_vau_csharp_test
                 long after = client.RequestCounter;
                 Assert.That((before + messageCount == after), $"Request counter should increment by {messageCount} after sending {messageCount} messages, but got {after}");
             });
+        }
+
+        [Test]
+        public async Task Incrementing_The_RequestCounter_Is_Thread_Safe()
+        {
+            const int requestCount = 75;
+            
+            var tasks = new Task[requestCount];
+            
+            for (int i = 0; i < requestCount; i++)
+            {
+                tasks[i] = Task.Run(() => client.EncryptVauMessage(Array.Empty<byte>()));
+            }
+            
+            await Task.WhenAll(tasks);
+            
+            Assert.That(client.RequestCounter, Is.EqualTo(requestCount));
         }
     }
 }

--- a/lib-vau-csharp/VauClientStateMachine.cs
+++ b/lib-vau-csharp/VauClientStateMachine.cs
@@ -22,6 +22,7 @@ using lib_vau_csharp.util;
 using Org.BouncyCastle.Security;
 using System;
 using System.Linq;
+using System.Threading;
 
 namespace lib_vau_csharp
 {
@@ -34,7 +35,7 @@ namespace lib_vau_csharp
         private byte[] clientTranscript = Array.Empty<byte>();
         private readonly Kem kem = Kem.initializeKem(Kem.KemEngines.AesEngine, Kem.KEYSIZE_256);
         private KdfMessage clientKemResult1, clientKemResult2;
-        private long requestCounter { get; set; } = 0;
+        private long requestCounter;
 
         public VauClientStateMachine()
         {
@@ -145,10 +146,7 @@ namespace lib_vau_csharp
         /// <summary>
         /// Increments the request counter (A_24628-*) and returns the new value.
         /// </summary>
-        protected override long GetRequestCounter()
-        {
-            return requestCounter += 1;
-        }
+        protected override long GetRequestCounter() => Interlocked.Increment(ref requestCounter);
 
         /// <summary>
         /// Gets the current request counter value (e.g., for verification in unit tests).


### PR DESCRIPTION
Reading and incrementing a value is not guaranteed to be an atomic operation. Use `Interlocked.Increment` to make this thread safe.